### PR TITLE
changed output to reduce log output

### DIFF
--- a/lib/fluent/plugin/out_couch.rb
+++ b/lib/fluent/plugin/out_couch.rb
@@ -48,7 +48,7 @@ module Fluent
                         @views.push([@refresh_view_index,view_name])
                     end
                     rescue
-                    puts 'design document not found!'
+                    $log.error 'design document not found!'
                 end
             end
         end
@@ -87,6 +87,7 @@ module Fluent
                         rescue
                     end
                     record['_rev']=doc['_rev'] unless doc.nil?
+                    $log.debug record
                     @db.save_doc(record) 
                 }
             end


### PR DESCRIPTION
Hi,

I've changed the puts to a $log to prevent this plugin sending all the couch data to stdout - it'll now log it if the loglevel is at debug (-vv)

Thanks

Chris
