### PR TITLE
Loosen Fluentd dependency

### DIFF
--- a/fluent-plugin-couch.gemspec
+++ b/fluent-plugin-couch.gemspec
@@ -29,16 +29,16 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<fluentd>, ["~> 0.10.0"])
+      s.add_runtime_dependency(%q<fluentd>, [">= 0.10.0", "< 2"])
       s.add_runtime_dependency(%q<couchrest>, ["~> 1.1.2"])
       s.add_runtime_dependency(%q<jsonpath>, ["~> 0.4.2"])
     else
-      s.add_dependency(%q<fluentd>, ["~> 0.10.0"])
+      s.add_dependency(%q<fluentd>, [">= 0.10.0", "< 2"])
       s.add_dependency(%q<couchrest>, ["~> 1.1.2"])
       s.add_dependency(%q<jsonpath>, ["~> 0.4.2"])
     end
   else
-    s.add_dependency(%q<fluentd>, ["~> 0.10.0"])
+    s.add_dependency(%q<fluentd>, [">= 0.10.0", "< 2"])
     s.add_dependency(%q<couchrest>, ["~> 1.1.2"])
     s.add_dependency(%q<jsonpath>, ["~> 0.4.2"])
   end


### PR DESCRIPTION
Fluentd v0.10.x no longer can install with Ruby 2.4.

I've confirmed that this plugin works with Ruby 2.4 and v0.14.11 with this change.