### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -31,8 +31,8 @@ Store fluent-event as CouchDB Document to CouchDB database.
       protocol https               #default:http
 
       update_docs true             #default:false
-      doc_key_field doc_id         #default:nil
-      doc_key_jsonpath $.event.key #default:nil
+      doc_key_field doc_id         #default:nil. ${tag} will be replaced with actual event's tag.
+      doc_key_jsonpath $.event.key #default:nil. ${tag} will be replaced with actual event's tag.
 
       refresh_view_index viewname  #default:nil
 

--- a/fluent-plugin-couch.gemspec
+++ b/fluent-plugin-couch.gemspec
@@ -32,20 +32,20 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<fluentd>.freeze, ["< 2", ">= 0.10.0"])
+      s.add_runtime_dependency(%q<fluentd>.freeze, ["< 2", ">= 0.14.0"])
       s.add_runtime_dependency(%q<couchrest>.freeze, ["~> 1.1.2"])
       s.add_runtime_dependency(%q<jsonpath>.freeze, ["~> 0.4.2"])
       s.add_development_dependency(%q<rake>, [">= 12.0.0"])
       s.add_development_dependency(%q<test-unit>, ["~> 3.2.0"])
     else
-      s.add_dependency(%q<fluentd>.freeze, ["< 2", ">= 0.10.0"])
+      s.add_dependency(%q<fluentd>.freeze, ["< 2", ">= 0.14.0"])
       s.add_dependency(%q<couchrest>.freeze, ["~> 1.1.2"])
       s.add_dependency(%q<jsonpath>.freeze, ["~> 0.4.2"])
       s.add_development_dependency(%q<rake>, [">= 12.0.0"])
       s.add_development_dependency(%q<test-unit>, ["~> 3.2.0"])
     end
   else
-    s.add_dependency(%q<fluentd>.freeze, ["< 2", ">= 0.10.0"])
+    s.add_dependency(%q<fluentd>.freeze, ["< 2", ">= 0.14.0"])
     s.add_dependency(%q<couchrest>.freeze, ["~> 1.1.2"])
     s.add_dependency(%q<jsonpath>.freeze, ["~> 0.4.2"])
     s.add_development_dependency(%q<rake>, [">= 12.0.0"])

--- a/fluent-plugin-couch.gemspec
+++ b/fluent-plugin-couch.gemspec
@@ -35,15 +35,20 @@ Gem::Specification.new do |s|
       s.add_runtime_dependency(%q<fluentd>.freeze, ["< 2", ">= 0.10.0"])
       s.add_runtime_dependency(%q<couchrest>.freeze, ["~> 1.1.2"])
       s.add_runtime_dependency(%q<jsonpath>.freeze, ["~> 0.4.2"])
+      s.add_development_dependency(%q<rake>, [">= 12.0.0"])
+      s.add_development_dependency(%q<test-unit>, ["~> 3.2.0"])
     else
       s.add_dependency(%q<fluentd>.freeze, ["< 2", ">= 0.10.0"])
       s.add_dependency(%q<couchrest>.freeze, ["~> 1.1.2"])
       s.add_dependency(%q<jsonpath>.freeze, ["~> 0.4.2"])
+      s.add_development_dependency(%q<rake>, [">= 12.0.0"])
+      s.add_development_dependency(%q<test-unit>, ["~> 3.2.0"])
     end
   else
     s.add_dependency(%q<fluentd>.freeze, ["< 2", ">= 0.10.0"])
     s.add_dependency(%q<couchrest>.freeze, ["~> 1.1.2"])
     s.add_dependency(%q<jsonpath>.freeze, ["~> 0.4.2"])
+    s.add_development_dependency(%q<rake>, [">= 12.0.0"])
+    s.add_development_dependency(%q<test-unit>, ["~> 3.2.0"])
   end
 end
-

--- a/lib/fluent/plugin/out_couch.rb
+++ b/lib/fluent/plugin/out_couch.rb
@@ -1,46 +1,55 @@
-module Fluent
-    class CouchOutput < BufferedOutput
+require "fluent/plugin/output"
+
+module Fluent::Plugin
+    class CouchOutput < Output
         attr_reader :db # for tests
 
-        include SetTagKeyMixin
+        DEFAULT_BUFFER_TYPE = "memory"
+
+        helpers :compat_parameters, :inject
+
         config_set_default :include_tag_key, false
-        
-        include SetTimeKeyMixin
         config_set_default :include_time_key, true
-        
+
         Fluent::Plugin.register_output('couch', self)
-        
+
         config_param :database, :string
-        
+
         config_param :host, :string, :default => 'localhost'
         config_param :port, :string, :default => '5984'
         config_param :protocol, :string, :default => 'http'
-        
+
         config_param :refresh_view_index , :string, :default => nil
-        
+
         config_param :user, :string, :default => nil
         config_param :password, :string, :default => nil, :secret => true
-        
+
         config_param :update_docs, :bool, :default => false
         config_param :doc_key_field, :string, :default => nil
         config_param :doc_key_jsonpath, :string, :default => nil
-        
+
+        config_section :buffer do
+            config_set_default :@type, DEFAULT_BUFFER_TYPE
+            config_set_default :chunk_keys, ['tag']
+        end
+
         def initialize
             super
-            
+
             require 'msgpack'
             require 'jsonpath'
             Encoding.default_internal = 'UTF-8'
             require 'couchrest'
             Encoding.default_internal = 'ASCII-8BIT'
         end
-        
+
         def configure(conf)
+            compat_parameters_convert(conf, :buffer, :inject)
             super
             account = "#{@user}:#{@password}@" if @user && @password
             @db = CouchRest.database!("#{@protocol}://#{account}#{@host}:#{@port}/#{@database}")
         end
-        
+
         def start
             super
             @views = []
@@ -54,19 +63,24 @@ module Fluent
                 end
             end
         end
-        
+
         def shutdown
             super
         end
-        
+
         def format(tag, time, record)
+            record = inject_values_to_record(tag, time, record)
             record.to_msgpack
         end
-        
+
+        def formatted_to_msgpack_binary
+            true
+        end
+
         def write(chunk)
             records = []
             chunk.msgpack_each {|record|
-                
+
                 id = record[@doc_key_field]
                 id = JsonPath.new(@doc_key_jsonpath).first(record) if id.nil? && !@doc_key_jsonpath.nil?
                 record['_id'] = id unless id.nil?
@@ -79,7 +93,7 @@ module Fluent
             end
             update_view_index
         end
-        
+
         def update_docs(records)
             if records.length > 0
                 records.each{|record|
@@ -90,11 +104,11 @@ module Fluent
                     end
                     record['_rev']=doc['_rev'] unless doc.nil?
                     $log.debug record
-                    @db.save_doc(record) 
+                    @db.save_doc(record)
                 }
             end
         end
-        
+
         def update_view_index()
             @views.each do |design,view|
                 @db.view("#{design}/#{view}",{"limit"=>"0"})

--- a/lib/fluent/plugin/out_couch.rb
+++ b/lib/fluent/plugin/out_couch.rb
@@ -59,7 +59,7 @@ module Fluent::Plugin
                         @views.push([@refresh_view_index,view_name])
                     end
                     rescue
-                    $log.error 'design document not found!'
+                    log.error 'design document not found!'
                 end
             end
         end
@@ -104,7 +104,7 @@ module Fluent::Plugin
                         rescue
                     end
                     record['_rev']=doc['_rev'] unless doc.nil?
-                    $log.debug record
+                    log.debug record
                     @db.save_doc(record)
                 }
             end


### PR DESCRIPTION
Using v0.14 API permits to refer nanosecond precision time in each of Fluentd plugins and to use built-in placeholder feature.
But, migrating to use v0.14 API must drop to support v0.12 or older.
If you merge this PR, you cannot support v0.12 and EOLed version of Fluentd anymore.

If there is any questions and comments, please let me know.